### PR TITLE
added sourceOnlyMode setting to plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ plugins: [
 | prefixDefault   | boolean  | if the value is `true` then the pages in the default language will also be preceded by the language in the path. Example: [locale] / [page] |
 | configPath      | string   | path of the config file                                                                                                                     |
 | waitingGatsbySourceShopify      | number   | every ms the plugin wait gatsby-source-shopify and retry to get translations                                                                                                                      |
+| sourceOnlyMode | boolean   | setting this to `true` disables injecting `i18next` into your page, you might want to activate this if you use your own `i18next` instance and use this plugin only to source Shopify translations. Default is `false`.|
 
 ## Translated resources in GraphQL Data Layer
 

--- a/src/plugin/onCreatePage.js
+++ b/src/plugin/onCreatePage.js
@@ -2,6 +2,7 @@ const { localizedPath, getLanguages } = require(`../helpers`)
 const { withDefaults } = require(`../utils/default-options`)
 
 exports.onCreatePage = ({ page, actions }, pluginOptions) => {
+  if (pluginOptions.sourceOnlyMode) return
   const { createPage, deletePage, createRedirect } = actions
   const { configPath, defaultLang, locales, prefixDefault } =
     withDefaults(pluginOptions)

--- a/src/plugin/wrapPageElement.js
+++ b/src/plugin/wrapPageElement.js
@@ -6,9 +6,9 @@ import { LocaleContext } from "../context"
 
 const wrapPageElement = (
   { element, props },
-  { locales, localeJsonNodeName = "locales" }
+  { locales, sourceOnlyMode, localeJsonNodeName = "locales" }
 ) => {
-  if (!props) return
+  if (!props || sourceOnlyMode) return
   const { data, pageContext } = props
   const { language, languages, originalPath, defaultLanguage, path } =
     pageContext

--- a/src/utils/default-options.js
+++ b/src/utils/default-options.js
@@ -13,6 +13,7 @@ function withDefaults(themeOptions) {
       ? themeOptions.prefixDefault
       : false,
     locales: themeOptions.locales || null,
+    sourceOnlyMode: themeOptions.sourceOnlyMode ? themeOptions.sourceOnlyMode : false
   }
 }
 


### PR DESCRIPTION
Hi,

I've added a config setting which disables `wrapPageElement` and therefore doesn't inject the `i18next` instance, this is useful if you want to use your own instance for example when using [gatsby-plugin-react-i18next](https://www.gatsbyjs.com/plugins/gatsby-plugin-react-i18next/) and only rely on this plugin for Shopify translation sourcing.