### PR TITLE
get metafield identifiers from api and update queries to use identifiers

### DIFF
--- a/src/operations.js
+++ b/src/operations.js
@@ -12,15 +12,15 @@ exports.createOperations = options => {
   }
 
   return {
-    createTranslatedProductsOperation: async ids => {
+    createTranslatedProductsOperation: async (ids, identifiers) => {
       return await createOperation(
-        translatedProductsQuery(ids),
+        translatedProductsQuery(ids, identifiers),
         "TRANSLATED_PRODUCTS"
       )
     },
-    createTranslatedCollectionsOperation: async ids => {
+    createTranslatedCollectionsOperation: async (ids, identifiers) => {
       return await createOperation(
-        translatedCollectionsQuery(ids),
+        translatedCollectionsQuery(ids, identifiers),
         "TRANSLATED_COLLECTIONS"
       )
     },

--- a/src/plugin/createSchemaCustomization.js
+++ b/src/plugin/createSchemaCustomization.js
@@ -34,18 +34,9 @@ exports.createSchemaCustomization = function ({ actions }) {
     }
 
     type Metafield {
-      id: String
+      namespace: String
       key: String
       value: String
-      description: String
-    }
-
-    type MetafieldNode {
-      node: Metafield
-    }
-
-    type MetafieldEdges {
-      edges: [MetafieldNode]
     }
 
     type Collection {
@@ -71,7 +62,7 @@ exports.createSchemaCustomization = function ({ actions }) {
       collections: CollectionEdges
       options: [Option]
       variants: VariantEdges
-      metafields: MetafieldEdges
+      metafields: [Metafield]
     }
 
     type ShopifyTranslatedCollection implements Node {

--- a/src/plugin/sourceNodes.js
+++ b/src/plugin/sourceNodes.js
@@ -38,7 +38,22 @@ async function sourceAllNodes(gatsbyApi, pluginOptions) {
   const { createNode } = actions
 
   for (const resource of resources) {
-    let translations = []
+    const metafieldIdentifiers = getNodesByType(
+      `Shopify${resource.id}Metafield`
+    )
+      .map((metafield) => {
+        const identifier = {
+          namespace: metafield.namespace,
+          key: metafield.key,
+        };
+        return identifier;
+      })
+      .filter(
+        (v, i, a) =>
+          a.findIndex((t) => JSON.stringify(t) === JSON.stringify(v)) === i
+      );
+
+    let translations = [];
 
     for (const lang of locales) {
       const op = resource.getOperation(pluginOptions, lang)
@@ -54,12 +69,15 @@ async function sourceAllNodes(gatsbyApi, pluginOptions) {
 
       for (let i = 0; i < callNumbers; i++) {
         const idsTranch = ids.splice(0, MAX_INPUT_RANGE)
-        const { data } = await op(idsTranch)
+        const { data } = await op(idsTranch,metafieldIdentifiers)
         const newTranslations = data.nodes
         .filter(node => !!node)
         .map(node => {
           return {
               ...node,
+              metafields: node.metafields
+              ? node.metafields.filter((metafield) => metafield)
+              : [],
               handle: slugify(node.title),
               storefrontId: node.id,
               locale: lang,

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,9 +1,12 @@
 const { gql } = require("@apollo/client")
 
-exports.translatedProductsQuery = ids => {
+exports.translatedProductsQuery = (ids, identifiers) => {
   return {
     query: gql`
-      query translatedThings($ids: [ID!]!) {
+      query translatedThings(
+        $ids: [ID!]!
+        $identifiers: [HasMetafieldsIdentifier!]!
+      ) {
         nodes(ids: $ids) {
           ... on Product {
             __typename
@@ -38,15 +41,10 @@ exports.translatedProductsQuery = ids => {
                 }
               }
             }
-            metafields(first: 30) {
-              edges {
-                node {
-                  id
-                  key
-                  value
-                  description
-                }
-              }
+            metafields(identifiers: $identifiers) {
+              key
+              value
+              namespace
             }
           }
         }
@@ -54,11 +52,12 @@ exports.translatedProductsQuery = ids => {
     `,
     variables: {
       ids,
+      identifiers,
     },
   }
 }
 
-exports.translatedCollectionsQuery = ids => {
+exports.translatedCollectionsQuery = (ids) => {
   return {
     query: gql`
       query translatedThings($ids: [ID!]!) {


### PR DESCRIPTION
fixes #11 

I have updated the syntax of metafield queries as the oldest supported API version has updated. Metafield identifier objects are now needed, so I grab those from the api and pass them to the queries.